### PR TITLE
Expose MathJax option "tags" as a command-line option

### DIFF
--- a/bin/mjcli.js
+++ b/bin/mjcli.js
@@ -63,7 +63,12 @@ var argv = require('yargs')
       describe: "output math as SVG",
       type: "boolean"
     },
-
+    tags: {
+      alias: "t",
+      default: "ams",
+      describe: "whether equations are numbered and how; 'ams', 'all', or 'none'",
+      type: "string"
+    },
     fontURL: {
       default: 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/output/chtml/fonts/woff-v2',
       describe: 'the URL to use for web fonts'
@@ -106,7 +111,12 @@ let tex = null;
 //  We support either MathML (default) or LaTeX math
 if(argv.latex==true) {
   const {TeX} = require('mathjax-full/js/input/tex.js');
-  tex = new TeX({packages: argv.packages.split(/\s*,\s*/), inlineMath: [['$','$'], ["\\(","\\)"]]});
+  tex = new TeX({
+    processEscapes: false,
+    packages: argv.packages.split(/\s*,\s*/),
+    inlineMath: [['$','$'], ["\\(","\\)"]],
+    tags: argv.tags
+  });
 } else {
   const {MathML} = require('mathjax-full/js/input/mathml.js');
   tex = new MathML();


### PR DESCRIPTION
This controls if and how labels and references are rendered.
Since the MathJax default is 'none', without a way to change this
option it is impossible to render labels with mjcli.

While the MathJax default is 'none', this commit sets the default
for mjcli to 'ams'.  The MathJax documentation states that the
'none' default has been chosen for backwards compatibility.
In practice, though, users most likely want support for labels.
For example, tex4ht in MathJax mode always uses 'aws'.